### PR TITLE
feature: stay the cursor on the line after copying

### DIFF
--- a/plugin/oscyank.vim
+++ b/plugin/oscyank.vim
@@ -48,6 +48,7 @@ function! VisualOSC52() range
   let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
   let lines[0] = lines[0][column_start - 1:]
   call YankOSC52(join(lines, "\n"))
+  execute "normal! `<"
 endfunction
 
 " This function base64's the entire string and wraps it in a single OSC52.


### PR DESCRIPTION
after copying the text, let the cursor stay on the words it is copied from instead of moving it to beginning of the line.

I tested this locally on my machine and it works. still very noob in vim script but hopefully it could be useful. let me know if you are interested in this feature but not working on your pc.

thank you.