### PR TITLE
Reintroduce OSCYankOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ You may want to map the command:
 vnoremap <leader>c :OSCYank<CR>
 ```
 
+You can also use the OSCYank operator:
+```vim
+nmap <leader>o <Plug>OSCYank
+```
+like so for instance:
+```
+<leader>oip  " copy the inner paragraph
+```
+(see [this PR](https://github.com/ojroques/vim-oscyank/pull/15) for more
+details)
+
 ## Copying from a register
 If you prefer to copy text from a particular register, use:
 ```vim

--- a/plugin/oscyank.vim
+++ b/plugin/oscyank.vim
@@ -58,6 +58,37 @@ function! OSCYankVisual() range
   execute "normal! `<"
 endfunction
 
+" Send the input text object to the terminal's clipboard using OSC52.
+function! OSCYankOperator(type, ...) abort
+  " Special case: if the user _has_ explicitly specified a register (or
+  " they've just supplied one of the possible defaults), OSCYank its contents.
+  if !(v:register ==# '"' || v:register ==# '*' || v:register ==# '+')
+    call OSCYankString(getreg(v:register))
+    return ''
+  endif
+
+  " Otherwise, do the usual operator dance (see `:help g@`).
+  if a:type == ''
+    set opfunc=OSCYankOperator
+    return 'g@'
+  endif
+
+  let [line_start, column_start] = getpos("'[")[1:2]
+  let [line_end, column_end] = getpos("']")[1:2]
+
+  let lines = getline(line_start, line_end)
+  if len(lines) == 0
+    return ''
+  endif
+
+  if a:type ==# "char"
+    let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
+    let lines[0] = lines[0][column_start - 1:]
+  endif
+
+  call OSCYankString(join(lines, "\n"))
+endfunction
+
 " This function base64's the entire string and wraps it in a single OSC52.
 " It's appropriate when running in a raw terminal that supports OSC 52.
 function! s:get_OSC52(str)
@@ -173,6 +204,8 @@ let s:b64_table = [
       \ "g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v",
       \ "w","x","y","z","0","1","2","3","4","5","6","7","8","9","+","/",
       \ ]
+
+nnoremap <silent> <expr> <Plug>OSCYank OSCYankOperator('')
 
 command! -range OSCYank <line1>,<line2>call OSCYankVisual()
 command! -nargs=1 OSCYankReg call OSCYankString(getreg(<f-args>))


### PR DESCRIPTION
The previous commit introducing OSCYankOperator `fe67f649111dc15336c9905b9aee28e242add358` was reverted in `bc49a0c2b5ded3f13445e47aa3cf8d3a0f972926` because it broke versions of Vim/Neovim that didn't have support for keyword arguments.

In order to be (more) backwards compatible we have to avoid using keyword arguments.

See #16 for more details.

In any case, this reintroduction commit adds an operator that can be used to OSCYank text objects. With this change, if you add the following to your config:
```
nmap <leader>o <Plug>OSCYank
```
... you will be able to do things such as:
```
<leader>oip
```
... to OSCYank an inner paragraph, or:
```
"k<leader>o
```
... to OSCYank the contents of "k.