### PR TITLE
Update README.md register copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ If you prefer to copy text from a particular register, use:
 For the impatient one, copy this line to your config. Content will be copied to
 clipboard after any yank operation:
 ```vim
-autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '' | OSCYankReg " | endif
+autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '' | execute 'OSCYankReg "' | endif
 ```
 
 Or to copy to clipboard the `+` register (vim's *system clipboard* register):
 ```vim
-autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | OSCYankReg + | endif
+autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | execute 'OSCYankReg +' | endif
 ```
 
 ## Configuration


### PR DESCRIPTION
Using https://github.com/machakann/vim-highlightedyank together with this plugin by using the following in `.vimrc` (notice that `autocmd` part is the same as in `README.md`:

```vim
call plug#begin('~/.vim/plugged')

Plug 'ojroques/vim-oscyank'
Plug 'machakann/vim-highlightedyank'

call plug#end()

autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | OSCYankReg + | endif
```

breaks `vim-highlightedyank` functionality. If you press `yy`, the yank is no longer highlighted.

And if you use the first example from the `README.md`:
```vim
autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '' | OSCYankReg " | endif
```
the highlight no longer works when you press `"+yy`.

Looks like it could be a similar issue as described here: https://vi.stackexchange.com/questions/13454/endif-treated-as-part-of-command-in-autocmd. The `endif` gets swallowed.

Found two possible fixes:
1. Start using -bar option with the command - `:h command-bar`
2. Wrap the command inside a string and execute with `execute` .

I've went with the second option, because I'm not sure what the first option could break and if it would be backwards compatible.
