### PR TITLE
Replace osc52 support table with can I use terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,8 @@ into the system clipboard.
 
 This is totally location-independent, you can copy text from anywhere including
 from remote SSH sessions. The only requirement is that the terminal must support
-the sequence. Here is a non-exhaustive list of the state of OSC52 integration in
-popular terminal emulators:
-
-| Terminal | OSC52 support |
-|----------|:-------------:|
-| [alacritty](https://github.com/alacritty/alacritty) | **yes** |
-| [contour](https://github.com/contour-terminal/contour) | **yes** |
-| [far2l](https://github.com/elfmz/far2l) | **yes** |
-| [foot](https://codeberg.org/dnkl/foot) | **yes** |
-| [gnome terminal](https://github.com/GNOME/gnome-terminal) (and other VTE-based terminals) | [not yet](https://gitlab.gnome.org/GNOME/vte/-/issues/2495) |
-| [hterm](https://chromium.googlesource.com/apps/libapps/+/master/README.md) | [**yes**](https://chromium.googlesource.com/apps/libapps/+/master/nassh/doc/FAQ.md#Is-OSC-52-aka-clipboard-operations_supported) |
-| [iterm2](https://iterm2.com/) | **yes** |
-| [kitty](https://github.com/kovidgoyal/kitty) | **yes** |
-| [konsole](https://konsole.kde.org/) | [not yet](https://bugs.kde.org/show_bug.cgi?id=372116) |
-| [qterminal](https://github.com/lxqt/qterminal#readme) | [not yet](https://github.com/lxqt/qterminal/issues/839)
-| [rxvt](http://rxvt.sourceforge.net/) | **yes** |
-| [st](https://st.suckless.org/) | **yes** (but needs to be enabled, see [here](https://git.suckless.org/st/commit/a2a704492b9f4d2408d180f7aeeacf4c789a1d67.html)) |
-| [terminal.app](https://en.wikipedia.org/wiki/Terminal_(macOS)) | no, but see [workaround](https://github.com/roy2220/osc52pty) |
-| [tmux](https://github.com/tmux/tmux) | **yes** |
-| [urxvt](http://software.schmorp.de/pkg/rxvt-unicode.html) | **yes** (with a script, see [here](https://github.com/ojroques/vim-oscyank/issues/4)) |
-| [wezterm](https://github.com/wez/wezterm) | [**yes**](https://wezfurlong.org/wezterm/escape-sequences.html#operating-system-command-sequences) |
-| [windows terminal](https://github.com/microsoft/terminal) | **yes** |
-| [xterm.js](https://xtermjs.org/) (Hyper terminal) | [not yet](https://github.com/xtermjs/xterm.js/issues/3260) |
-| [zellij](https://github.com/zellij-org/zellij/) | **yes** |
+the sequence. A non-exhaustive list of the state of OSC52 integration in
+popular terminal emulators [is here](https://can-i-use-terminal.github.io/features/osc52copy.html).
 
 Feel free to add terminals to this list by submitting a pull request.
 


### PR DESCRIPTION
[Can I use terminal](https://can-i-use-terminal.github.io/) is a site for support tables of terminal emulator features. Seeing this list and some other lists like https://arewesixelyet.rs/ I decided to create this site for better discoverability and collecting all the data in a single place. You can see its osc52 page at https://can-i-use-terminal.github.io/features/osc52copy.html

It includes more terminals than current list, and includes some recent data that are outdated in this list. In addition to that, by merging these parallel lists (another one is [here](https://github.com/jirutka/tty-copy?tab=readme-ov-file#supported-terminals)) in a single place, it can reduce maintenance cost in community and result in higher quality and more up to date data.