### PR TITLE
use built-in base64_encode if available

### DIFF
--- a/plugin/oscyank.vim
+++ b/plugin/oscyank.vim
@@ -1,3 +1,4 @@
+
 " -------------------- INIT --------------------------------
 if exists('g:loaded_oscyank')
   finish
@@ -38,6 +39,12 @@ function s:echo(text, hl)
   echohl None
 endfunction
 
+if exists(*base64_encode')
+  function s:encode_b64(str, size)
+    return a:size <= 0 ?
+          \ base64_encode(a:str) : strpart(base64_encode(a:str), a:size)
+  endfunction
+else
 function s:encode_b64(str, size)
   let bytes = map(range(len(a:str)), 'char2nr(a:str[v:val])')
   let b64 = []
@@ -74,6 +81,7 @@ function s:encode_b64(str, size)
 
   return chunked
 endfunction
+endif
 
 function s:get_text(mode, type)
   " Save user settings


### PR DESCRIPTION
In https://github.com/ojroques/vim-oscyank/blob/4b068e5b553f907c5f6d00b0ab9e1e3b98cf71bf/plugin/oscyank.vim#L41 it might make sense to check for https://github.com/vim/vim/commit/810785c6890ef0a1cd2428410c8488cacfbac77b