### PR TITLE
docs: Add delete to advanced example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ if (!has('nvim') && !has('clipboard_working'))
     " can be the case that `has('clipboard_working')` is false, yet `+` is
     " still distinct, so we want to check them all.
     let s:VimOSCYankPostRegisters = ['', '+', '*']
+    " copy text to clipboard on both (y)ank and (d)elete
+    let s:VimOSCYankOperators = ['y', 'd']
     function! s:VimOSCYankPostCallback(event)
-        if a:event.operator == 'y' && index(s:VimOSCYankPostRegisters, a:event.regname) != -1
+        if index(s:VimOSCYankPostRegisters, a:event.regname) != -1
+            \ && index(s:VimOSCYankOperators, a:event.operator) != -1
             call OSCYankRegister(a:event.regname)
         endif
     endfunction


### PR DESCRIPTION
This is an amazing plugin and frankly the first readable vim script I have seen so far. Just set it up on z/OS  with the recent port of vim running in kitty terminal. It is a live saver.

The only thing I missed was copying to the clipboard on delete. This is useful when moving code between terminals and windows.

It is a trivial change to the docs, but I believe it makes the plugin even more useful.

Thank you!!!